### PR TITLE
Feat/#46 currentperson board게시물에서 삭제 및 sse 연동

### DIFF
--- a/src/board/board.controller.ts
+++ b/src/board/board.controller.ts
@@ -97,15 +97,4 @@ export class BoardController {
     await this.boardService.removeBoard(id);
     return { message: 'board가 성공적으로 삭제되었습니다.' };
   }
-
-  // @ApiOperation({ summary: '현재 참여한 인원 조회' })
-  // @ApiBearerAuth()
-  // @UseGuards(AuthGuard)
-  // @Get(':id/current-person')
-  // async getCurrentPerson(
-  //   @Param('id') id: number,
-  // ): Promise<{ currentPerson: number }> {
-  //   const currentPerson = this.boardService.getCurrentCapacity(id);
-  //   return { currentPerson };
-  // }
 }

--- a/src/board/board.controller.ts
+++ b/src/board/board.controller.ts
@@ -98,14 +98,14 @@ export class BoardController {
     return { message: 'board가 성공적으로 삭제되었습니다.' };
   }
 
-  @ApiOperation({ summary: '현재 참여한 인원 조회' })
-  @ApiBearerAuth()
-  @UseGuards(AuthGuard)
-  @Get(':id/current-person')
-  async getCurrentPerson(
-    @Param('id') id: number,
-  ): Promise<{ currentPerson: number }> {
-    const currentPerson = this.boardService.getCurrentCapacity(id);
-    return { currentPerson };
-  }
+  // @ApiOperation({ summary: '현재 참여한 인원 조회' })
+  // @ApiBearerAuth()
+  // @UseGuards(AuthGuard)
+  // @Get(':id/current-person')
+  // async getCurrentPerson(
+  //   @Param('id') id: number,
+  // ): Promise<{ currentPerson: number }> {
+  //   const currentPerson = this.boardService.getCurrentCapacity(id);
+  //   return { currentPerson };
+  // }
 }

--- a/src/board/board.service.ts
+++ b/src/board/board.service.ts
@@ -88,7 +88,7 @@ export class BoardService {
         `사용자 ${user.id}가 채팅방 ID: ${chatRoom.id}에 참여하였습니다`,
       );
 
-      return this.toBoardResponseDto(savedBoard, user.id, false, 0); // 기본값 0을 전달
+      return this.toBoardResponseDto(savedBoard, user.id, false); // 기본값 0을 전달하지 않음
     } catch (error) {
       if (error.name === 'TokenExpiredError') {
         this.logger.error('유효하지 않은 토큰: ', error);
@@ -105,12 +105,6 @@ export class BoardService {
     }
   }
 
-  // updateCurrentCapacity를 통해 최신 currentPerson 값을 관리
-  public updateCurrentCapacity(boardId: number, capacity: number): void {
-    this.currentCapacity[boardId] = capacity;
-  }
-
-  // findOne 메서드에서 최신 currentPerson 값을 반영
   async findOne(id: number, userId: number): Promise<BoardResponseDto> {
     const board = await this.boardRepository.findOne({
       where: { id },
@@ -121,12 +115,12 @@ export class BoardService {
       throw new NotFoundException(`Board with ID ${id} not found`);
     }
 
-    // BoardService에서 최신 currentPerson 값을 반영
-    const currentCapacity = this.getCurrentPerson(board.id);
-    return this.toBoardResponseDto(board, userId, false, currentCapacity);
+    // ChatRoomService에서 현재 인원 수를 가져오기
+    const currentCapacity =
+      await this.chatRoomService.getCurrentCapacityForBoard(id);
+    return this.toBoardResponseDto(board, userId, false);
   }
 
-  // findAll 메서드에서도 동일하게 적용
   async findAll(
     paginationParams?: PaginationParamsDto,
   ): Promise<PaginationBoardsResponseDto> {
@@ -144,10 +138,14 @@ export class BoardService {
 
     const totalPage = Math.ceil(totalCount / limit);
 
-    const data = boards.map((board) => {
-      const currentCapacity = this.getCurrentPerson(board.id); // 현재 인원 수 계산
-      return this.toBoardResponseDto(board, undefined, false, currentCapacity);
-    });
+    const data = await Promise.all(
+      boards.map(async (board) => {
+        // Fetch the current capacity from ChatRoomService
+        const currentCapacity =
+          await this.chatRoomService.getCurrentCapacityForBoard(board.id);
+        return this.toBoardResponseDto(board, undefined, false);
+      }),
+    );
 
     return {
       data,
@@ -199,12 +197,7 @@ export class BoardService {
     const savedBoard = await this.boardRepository.save(updatedBoard);
 
     // 업데이트된 게시물을 응답 형식으로 변환하여 반환
-    return this.toBoardResponseDto(
-      savedBoard,
-      userId,
-      false,
-      this.getCurrentPerson(savedBoard.id),
-    );
+    return this.toBoardResponseDto(savedBoard, userId, false);
   }
 
   async removeBoard(id: number): Promise<void> {
@@ -228,7 +221,6 @@ export class BoardService {
     board: Board,
     userId: number,
     initial: boolean,
-    currentCapacity: number, // 현재 인원 수를 받는 매개변수 추가
   ): BoardResponseDto {
     const {
       id,
@@ -246,7 +238,6 @@ export class BoardService {
     } = board;
 
     const status = new Date(board.date) > new Date() ? 'OPEN' : 'CLOSE';
-    const currentPerson = currentCapacity || 0; // 전달받은 currentCapacity 값을 사용
 
     const editable = user.id === userId;
 
@@ -254,7 +245,7 @@ export class BoardService {
       id,
       title,
       maxCapacity: max_capacity,
-      currentPerson,
+      // currentPerson is removed
       description,
       startTime: start_time,
       date,

--- a/src/board/dto/board-response.dto.ts
+++ b/src/board/dto/board-response.dto.ts
@@ -62,8 +62,8 @@ export class BoardResponseDto {
   @ApiProperty()
   status: string;
 
-  @ApiProperty()
-  currentPerson: number;
+  // @ApiProperty()
+  // currentPerson: number;
 
   @ApiProperty()
   editable: boolean;

--- a/src/chat-room/chat-room.controller.ts
+++ b/src/chat-room/chat-room.controller.ts
@@ -29,6 +29,7 @@ import { Request } from 'express';
 @Controller('api/v1/chatrooms')
 @UseGuards(AuthGuard)
 export class ChatRoomController {
+  s;
   private readonly logger = new Logger(ChatRoomController.name);
 
   constructor(
@@ -122,22 +123,22 @@ export class ChatRoomController {
    */
   @ApiBearerAuth()
   @ApiOperation({ summary: '채팅방 나가기' })
-  @Delete(':chatRoomId/leave')
+  @Delete(':boardId/leave')
   @HttpCode(204)
   async leaveChatRoom(
-    @Token('sub') id: number,
-    @Param('chatRoomId', ParseIntPipe) chatRoomId: number,
+    @Token('sub') id: number, // 토큰에서 userId 추출
+    @Param('boardId', ParseIntPipe) boardId: number,
     @Req() request: Request,
   ) {
+    this.logger.log(
+      `User ${id} is leaving chat room associated with board ${boardId}`,
+    );
+
     const token = request.cookies['accessToken'];
     if (!token) {
       throw new UnauthorizedException('JWT token is missing');
     }
 
-    const payload = await this.chatRoomService.verifyToken(token);
-    const userId = payload.userId;
-
-    this.logger.log(`User ${userId} is leaving chat room ${chatRoomId}`);
-    return this.chatRoomService.leaveChatRoom(chatRoomId, userId);
+    return this.chatRoomService.leaveChatRoomByBoardId(boardId, id); // id를 userId로 사용
   }
 }

--- a/src/chat-room/chat-room.module.ts
+++ b/src/chat-room/chat-room.module.ts
@@ -9,6 +9,7 @@ import { EventsModule } from '../evnets/evnets.module';
 import { MessageModule } from '../message/message.module';
 import { Board } from '../board/entities/board.entity';
 import { UserModule } from '../user/user.module';
+import { BoardsModule } from '../board/board.module';
 
 @Module({
   imports: [
@@ -16,6 +17,7 @@ import { UserModule } from '../user/user.module';
     MessageModule,
     forwardRef(() => EventsModule),
     UserModule,
+    forwardRef(() => BoardsModule),
   ],
   controllers: [ChatRoomController],
   providers: [ChatRoomService],

--- a/src/evnets/events.gateway.ts
+++ b/src/evnets/events.gateway.ts
@@ -38,7 +38,7 @@ export class EventsGateway implements OnGatewayConnection, OnGatewayDisconnect {
     ) {
       // client.id 대신 사용자의 실제 ID를 전달합니다.
       const userId = parseInt(client.data.userId, 10); // client.data.userId가 있다고 가정
-      this.chatRoomService.leaveChatRoom(
+      this.chatRoomService.leaveChatRoomByBoardId(
         parseInt(chatRoomId.split(':')[1]),
         userId,
       );
@@ -46,7 +46,6 @@ export class EventsGateway implements OnGatewayConnection, OnGatewayDisconnect {
     }
     this.logger.log('Client disconnected: ' + client.id);
   }
-
   broadcastMessage(event: string, message: any) {
     this.logger.log(`Broadcasting message: ${JSON.stringify(message)}`);
     this.server.emit(event, message);


### PR DESCRIPTION
## Summary
<!-- 한 줄 설명* -->
  **'게시물 전체 조회'** 랑 **'특정 게시물 조회하기'** 할 때 currentPerson을 이제 sse 실시간성으로 연동할거니까 responsebody에서는 뺌


## Description
<!-- *어떤 코드가 추가/변경 됐는지* -->
 ## sse 변경
- 이제 cookie에 토큰이 있으니까 이제 클릭만 해도 누구인지 가지고 올 수 있게 해줌

### 참여하기
<img width="570" alt="image" src="https://github.com/user-attachments/assets/e7846076-6144-44b5-bcf5-3c03ffb323aa">

### 나가기
<img width="573" alt="image" src="https://github.com/user-attachments/assets/027f0045-f455-4156-ac9b-72787f795d9f">

### 결과물
<img width="666" alt="image" src="https://github.com/user-attachments/assets/2c4082b4-5123-4611-928a-c0924f7812d5">


## 게시물 전체 조회랑 게시물 특정 조회에 currentperson 삭제
이제 sse로  실시간성으로 연동하니까 필요없음

### 게시물 전체 조회
<img width="578" alt="image" src="https://github.com/user-attachments/assets/34c8cfe5-007d-4b92-b633-c6eb9e2137bc">

### 게시물 특정 조회 
<img width="569" alt="image" src="https://github.com/user-attachments/assets/4f603697-1b9e-4314-98af-9882e8ee87b1">


## Test Checklist
<!--  *테스트할 사람이 어떤 것을 확인하면 좋을지* -->
- [ ] @baekjiyun 백
- [ ] @suhyeon0921 
- [ ] @non-cpu 
- [ ] @Kimyebin00 
