### PR TITLE
fix: 같은 유저 재입장 불가

### DIFF
--- a/src/chat-room/chat-room.service.ts
+++ b/src/chat-room/chat-room.service.ts
@@ -109,6 +109,14 @@ export class ChatRoomService {
       throw new UnauthorizedException('채팅방의 최대 인원이 초과되었습니다');
     }
 
+    //동일한 유저가 이미 같은 chatRoomId에 들어가 있는지 확인
+    if (
+      this.participants[chatRoomId] &&
+      this.participants[chatRoomId].has(userId)
+    ) {
+      throw new Error('user가 이미 방에 들어가있습니다.');
+    }
+
     this.currentCapacity[chatRoomId] =
       (this.currentCapacity[chatRoomId] || 0) + 1;
 


### PR DESCRIPTION
## Summary
<!-- 한 줄 설명* -->
- 같은 유저가 재입장되는 문제점 발생

## Description
<!-- *어떤 코드가 추가/변경 됐는지* -->
```
//동일한 유저가 이미 같은 chatRoomId에 들어가 있는지 확인
    if (
      this.participants[chatRoomId] &&
      this.participants[chatRoomId].has(userId)
    ) {
      throw new Error('user가 이미 방에 들어가있습니다.');
    }

```


## Screenshots
<!-- *실행 결과 스크린샷* -->
<img width="1142" alt="스크린샷 2024-08-31 오전 3 03 24" src="https://github.com/user-attachments/assets/44ae62bf-1304-437f-812a-7d977bb4fbdd">

<img width="828" alt="스크린샷 2024-08-31 오전 3 04 08" src="https://github.com/user-attachments/assets/79a0a950-7ed5-44dc-9ed8-16eb04d3d2e3">


## Test Checklist
<!--  *테스트할 사람이 어떤 것을 확인하면 좋을지* -->
- [ ] @Kimyebin00 
