### PR TITLE
[refactor] board 리팩토링

### DIFF
--- a/src/board/board.module.ts
+++ b/src/board/board.module.ts
@@ -7,6 +7,7 @@ import { UserModule } from '../user/user.module';
 import { LocationModule } from '../location/location.module';
 import { ChatRoomModule } from '../chat-room/chat-room.module';
 import { Message } from '../message/entities/message.entity';
+import { BoardMapper } from './dto/board.mapper';
 
 @Module({
   imports: [
@@ -16,7 +17,7 @@ import { Message } from '../message/entities/message.entity';
     forwardRef(() => ChatRoomModule),
   ],
   controllers: [BoardController],
-  providers: [BoardService],
+  providers: [BoardService, BoardMapper],
   exports: [BoardService],
 })
 export class BoardsModule {}

--- a/src/board/board.service.ts
+++ b/src/board/board.service.ts
@@ -7,45 +7,41 @@ import {
   UnauthorizedException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { DataSource, DeepPartial, Repository } from 'typeorm';
+import { DataSource, DeepPartial, QueryRunner, Repository } from 'typeorm';
 import { Board } from './entities/board.entity';
 import { CreateBoardDto } from './dto/create-board';
 import { UpdateBoardDto } from './dto/update-board';
 import { LocationService } from '../location/location.service';
 import { ChatRoomService } from '../chat-room/chat-room.service';
-import { Subject } from 'rxjs';
 import { BoardResponseDto } from './dto/board-response.dto';
 import { Location } from '../location/entities/location.entity';
-import { SseResponseDto } from '../sse/dto/sse-response.dto';
 import { PaginationParamsDto } from './dto/pagination-params.dto';
 import { PaginationBoardsResponseDto } from './dto/pagination-boards-response.dto';
 import { Message } from '../message/entities/message.entity';
 import { User } from '../user/entities/user.entity';
 import { ChatRoom } from '../chat-room/entities/chat-room.entity';
+import { BoardMapper } from './dto/board.mapper';
 
 @Injectable()
 export class BoardService {
-  private readonly logger = new Logger(BoardService.name);
-  private boardUpdates: { [key: number]: Subject<SseResponseDto> } = {};
-  private currentCapacity: { [key: number]: number } = {};
+  private readonly logger: Logger = new Logger(BoardService.name);
 
   constructor(
     @InjectRepository(Board)
     private readonly boardRepository: Repository<Board>,
-    @InjectRepository(User)
-    private readonly userRepository: Repository<User>,
     @InjectRepository(Message)
     private readonly messageRepository: Repository<Message>,
     private readonly locationService: LocationService,
     private readonly chatRoomService: ChatRoomService,
     private dataSource: DataSource,
+    private readonly boardMapper: BoardMapper,
   ) {}
 
   async createBoard(
     createBoardDto: CreateBoardDto,
     userId: number,
   ): Promise<BoardResponseDto> {
-    const queryRunner = this.dataSource.createQueryRunner();
+    const queryRunner: QueryRunner = this.dataSource.createQueryRunner();
 
     await queryRunner.connect();
     await queryRunner.startTransaction();
@@ -55,7 +51,9 @@ export class BoardService {
         where: { id: userId },
       });
       if (!user) {
-        throw new NotFoundException('User not found');
+        throw new NotFoundException(
+          `ID가 ${userId}인 사용자를 찾을 수 없습니다.`,
+        );
       }
 
       const newLocation: Location = await this.getOrCreateLocation(
@@ -91,12 +89,10 @@ export class BoardService {
         `게시판과 채팅방이 생성되었습니다. Board ID: ${savedBoard.id}, ChatRoom ID: ${chatRoom.id}`,
       );
 
-      console.log(chatRoom.member_count);
-
-      return this.toBoardResponseDto(
+      return this.boardMapper.toBoardResponseDto(
         savedBoard,
         user.id,
-        chatRoom.member_count, // 채팅방의 현재 인원수를 보여주도록 했으나, currentCapacity 객체의 값이 필요해지면 변경이 필요함.
+        chatRoom.member_count,
       );
     } catch (err) {
       await queryRunner.rollbackTransaction();
@@ -119,7 +115,7 @@ export class BoardService {
     paginationParams?: PaginationParamsDto,
   ): Promise<PaginationBoardsResponseDto> {
     const { page, limit } = paginationParams;
-    const skip = (page - 1) * limit;
+    const skip: number = (page - 1) * limit;
 
     const [boards, totalCount] = await this.boardRepository.findAndCount({
       relations: ['user', 'location'],
@@ -128,14 +124,23 @@ export class BoardService {
       order: { updatedAt: 'DESC' },
     });
 
-    const totalPage = Math.ceil(totalCount / limit);
+    const totalPage: number = Math.ceil(totalCount / limit);
 
-    const data = await Promise.all(
-      boards.map(async (board) => {
-        const currentCapacity =
-          await this.chatRoomService.getCurrentCapacityForBoard(board.id);
-        this.currentCapacity[board.id] = currentCapacity; // 초기 용량 저장
-        return this.toBoardResponseDto(board, undefined, currentCapacity);
+    const data: BoardResponseDto[] = await Promise.all(
+      boards.map(async (board: Board) => {
+        const chatRoom: ChatRoom =
+          await this.chatRoomService.findChatRoomByBoardId(board.id);
+        if (!chatRoom) {
+          throw new NotFoundException(
+            '게시판에 연결된 채팅방을 찾을 수 없습니다.',
+          );
+        }
+
+        return this.boardMapper.toBoardResponseDto(
+          board,
+          undefined,
+          chatRoom.member_count,
+        );
       }),
     );
 
@@ -153,41 +158,29 @@ export class BoardService {
       where: { id },
       relations: ['user', 'location'],
     });
-
     if (!board) {
       throw new NotFoundException(`ID가 ${id}인 게시판을 찾을 수 없습니다.`);
     }
 
-    const currentCapacity =
-      await this.chatRoomService.getCurrentCapacityForBoard(id);
-    const editable = board.user.id === userId;
-
-    return this.toBoardResponseDto(board, userId, currentCapacity);
-  }
-
-  public async handleBoardUpdate(boardId: number): Promise<void> {
-    const chatRoom = await this.chatRoomService.findChatRoomByBoardId(boardId);
-    const currentCapacity =
-      await this.chatRoomService.getCurrentCapacityForBoard(boardId);
-
-    if (this.currentCapacity[boardId] !== currentCapacity) {
-      this.currentCapacity[boardId] = currentCapacity;
-      const sseResponse: SseResponseDto = {
-        currentPerson: currentCapacity,
-        nickName: '', // 빈 문자열을 사용하여 nickName을 처리
-        chatRoomId: chatRoom.id,
-      };
-      if (this.boardUpdates[boardId]) {
-        this.boardUpdates[boardId].next(sseResponse);
-      }
+    const chatRoom: ChatRoom =
+      await this.chatRoomService.findChatRoomByBoardId(id);
+    if (!chatRoom) {
+      throw new NotFoundException('게시판에 연결된 채팅방을 찾을 수 없습니다.');
     }
+
+    return this.boardMapper.toBoardResponseDto(
+      board,
+      userId,
+      chatRoom.member_count,
+    );
   }
+
   async updateBoard(
     id: number,
     userId: number,
     updateBoardDto: UpdateBoardDto,
   ): Promise<BoardResponseDto> {
-    const board = await this.boardRepository.findOne({
+    const board: Board = await this.boardRepository.findOne({
       where: { id },
       relations: ['user', 'location'],
     });
@@ -198,35 +191,31 @@ export class BoardService {
 
     if (board.user.id !== userId) {
       throw new UnauthorizedException(
-        'You do not have permission to update this board.',
+        '게시글을 수정할 권한이 없습니다. 게시글 작성자만 수정할 수 있습니다.',
       );
     }
 
-    const updatedLocation = updateBoardDto.location
-      ? await this.locationService.updateLocation({
-          ...board.location,
-          ...updateBoardDto.location,
-          location_name: updateBoardDto.locationName,
-        })
-      : board.location;
+    const updatedBoard: Board = await this.boardMapper.updateBoardFromDto(
+      board,
+      updateBoardDto,
+    );
+    const savedBoard: Board = await this.boardRepository.save(updatedBoard);
 
-    const updatedBoard = this.boardRepository.merge(board, {
-      ...updateBoardDto,
-      location: updatedLocation,
-      start_time: updateBoardDto.startTime || board.start_time,
-    });
+    const chatRoom: ChatRoom =
+      await this.chatRoomService.findChatRoomByBoardId(id);
+    if (!chatRoom) {
+      throw new NotFoundException('게시판에 연결된 채팅방을 찾을 수 없습니다.');
+    }
 
-    const savedBoard = await this.boardRepository.save(updatedBoard);
-
-    return this.toBoardResponseDto(
+    return this.boardMapper.toBoardResponseDto(
       savedBoard,
       userId,
-      this.currentCapacity[id] || 0,
+      chatRoom.member_count || 0,
     );
   }
 
   async removeBoard(id: number, userId: number): Promise<void> {
-    const board = await this.boardRepository.findOne({
+    const board: Board = await this.boardRepository.findOne({
       where: { id },
       relations: ['user', 'chat_room', 'chat_room.messages'],
     });
@@ -247,67 +236,15 @@ export class BoardService {
     await this.boardRepository.remove(board);
   }
 
-  public toBoardResponseDto(
-    board: Board,
-    userId: number | undefined,
-    currentCapacity: number,
-  ): BoardResponseDto {
-    const {
-      id,
-      title,
-      max_capacity,
-      description,
-      start_time,
-      date,
-      category,
-      createdAt,
-      updatedAt,
-      deletedAt,
-      user,
-      location,
-    } = board;
-
-    const status = new Date(board.date) > new Date() ? 'OPEN' : 'CLOSE';
-
-    // 기본 response 객체 생성 (editable 없이)
-    const response: BoardResponseDto = {
-      id,
-      title,
-      maxCapacity: max_capacity,
-      currentCapacity,
-      description,
-      startTime: start_time,
-      date,
-      category,
-      location: {
-        id: location.id,
-        latitude: location.latitude,
-        longitude: location.longitude,
-        locationName: location.location_name,
-      },
-      createdAt,
-      updatedAt,
-      deletedAt,
-      status,
-      user: user ? { userId: user.id, username: user.username } : undefined,
-    };
-
-    // userId가 있는 경우에만 editable을 추가
-    if (userId !== undefined) {
-      response.editable = user.id === userId;
-    }
-
-    return response;
-  }
-
   private async getOrCreateLocation(
     location: { latitude: number; longitude: number },
     location_name: string,
   ): Promise<Location> {
-    let newLocation = await this.locationService.findLocationByCoordinates(
-      location.latitude,
-      location.longitude,
-    );
+    let newLocation: Location =
+      await this.locationService.findLocationByCoordinates(
+        location.latitude,
+        location.longitude,
+      );
 
     if (!newLocation) {
       newLocation = await this.locationService.createLocation({

--- a/src/board/dto/board-response.dto.ts
+++ b/src/board/dto/board-response.dto.ts
@@ -1,10 +1,10 @@
 import { ApiProperty } from '@nestjs/swagger';
 import {
-  IsString,
-  IsNumber,
   IsDate,
-  IsOptional,
   IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  IsString,
 } from 'class-validator';
 
 class UserDto {
@@ -108,7 +108,7 @@ export class BoardResponseDto {
   @ApiProperty()
   @IsNumber()
   @IsNotEmpty()
-  currentCapacity: number;
+  currentPerson: number;
 
   @ApiProperty()
   @IsNotEmpty()

--- a/src/board/dto/board.mapper.ts
+++ b/src/board/dto/board.mapper.ts
@@ -29,8 +29,7 @@ export class BoardMapper {
     } = board;
     const status = new Date(board.date) > new Date() ? 'OPEN' : 'CLOSE';
 
-    // 기본 response 객체 생성 (editable 없이)
-    const response: BoardResponseDto = {
+    return {
       id,
       title,
       maxCapacity: max_capacity,
@@ -50,14 +49,8 @@ export class BoardMapper {
       deletedAt,
       status,
       user: user ? { userId: user.id, username: user.username } : undefined,
+      editable: userId === user.id,
     };
-
-    // userId가 있는 경우에만 editable을 추가
-    if (userId) {
-      response.editable = user.id === userId;
-    }
-
-    return response;
   }
 
   async updateBoardFromDto(

--- a/src/board/dto/board.mapper.ts
+++ b/src/board/dto/board.mapper.ts
@@ -1,0 +1,90 @@
+import { Injectable } from '@nestjs/common';
+import { Board } from '../entities/board.entity';
+import { BoardResponseDto } from './board-response.dto';
+import { UpdateBoardDto } from './update-board';
+import { LocationService } from '../../location/location.service';
+
+@Injectable()
+export class BoardMapper {
+  constructor(private readonly locationService: LocationService) {}
+
+  toBoardResponseDto(
+    board: Board,
+    userId: number | undefined,
+    currentPerson: number,
+  ): BoardResponseDto {
+    const {
+      id,
+      title,
+      max_capacity,
+      description,
+      start_time,
+      date,
+      category,
+      createdAt,
+      updatedAt,
+      deletedAt,
+      user,
+      location,
+    } = board;
+
+    const status = new Date(board.date) > new Date() ? 'OPEN' : 'CLOSE';
+
+    // 기본 response 객체 생성 (editable 없이)
+    const response: BoardResponseDto = {
+      id,
+      title,
+      maxCapacity: max_capacity,
+      currentPerson,
+      description,
+      startTime: start_time,
+      date,
+      category,
+      location: {
+        id: location.id,
+        latitude: location.latitude,
+        longitude: location.longitude,
+        locationName: location.location_name,
+      },
+      createdAt,
+      updatedAt,
+      deletedAt,
+      status,
+      user: user ? { userId: user.id, username: user.username } : undefined,
+    };
+
+    // userId가 있는 경우에만 editable을 추가
+    if (userId !== undefined) {
+      response.editable = user.id === userId;
+    }
+
+    return response;
+  }
+
+  async updateBoardFromDto(
+    board: Board,
+    updateBoardDto: Partial<UpdateBoardDto>,
+  ): Promise<Board> {
+    if (updateBoardDto.location || updateBoardDto.locationName) {
+      board.location = await this.locationService.updateLocation({
+        ...board.location,
+        ...updateBoardDto.location,
+        location_name:
+          updateBoardDto.locationName || board.location.location_name,
+      });
+    }
+
+    if (updateBoardDto.title !== undefined) board.title = updateBoardDto.title;
+    if (updateBoardDto.category !== undefined)
+      board.category = updateBoardDto.category;
+    if (updateBoardDto.description !== undefined)
+      board.description = updateBoardDto.description;
+    if (updateBoardDto.maxCapacity !== undefined)
+      board.max_capacity = updateBoardDto.maxCapacity;
+    if (updateBoardDto.date !== undefined) board.date = updateBoardDto.date;
+    if (updateBoardDto.startTime !== undefined)
+      board.start_time = updateBoardDto.startTime;
+
+    return board;
+  }
+}

--- a/src/board/dto/board.mapper.ts
+++ b/src/board/dto/board.mapper.ts
@@ -27,7 +27,6 @@ export class BoardMapper {
       user,
       location,
     } = board;
-
     const status = new Date(board.date) > new Date() ? 'OPEN' : 'CLOSE';
 
     // 기본 response 객체 생성 (editable 없이)
@@ -54,7 +53,7 @@ export class BoardMapper {
     };
 
     // userId가 있는 경우에만 editable을 추가
-    if (userId !== undefined) {
+    if (userId) {
       response.editable = user.id === userId;
     }
 

--- a/src/board/dto/board.mapper.ts
+++ b/src/board/dto/board.mapper.ts
@@ -3,6 +3,7 @@ import { Board } from '../entities/board.entity';
 import { BoardResponseDto } from './board-response.dto';
 import { UpdateBoardDto } from './update-board';
 import { LocationService } from '../../location/location.service';
+import { ChatRoom } from '../../chat-room/entities/chat-room.entity';
 
 @Injectable()
 export class BoardMapper {
@@ -78,5 +79,38 @@ export class BoardMapper {
       board.start_time = updateBoardDto.startTime;
 
     return board;
+  }
+
+  async mapBoardToBoardResponseDto(
+    board: Board,
+    chatRoom: ChatRoom,
+  ): Promise<BoardResponseDto | null> {
+    if (!chatRoom || !board) {
+      console.log(
+        `채팅방 또는 게시글을 찾을 수 없습니다. boardId: ${board?.id}, chatRoomId: ${chatRoom?.id}`,
+      );
+      return null;
+    }
+
+    return {
+      id: board.id,
+      title: board.title,
+      currentPerson: chatRoom.member_count,
+      maxCapacity: board.max_capacity,
+      description: board.description,
+      startTime: board.start_time,
+      category: board.category,
+      location: {
+        id: board.location?.id || 0,
+        latitude: board.location?.latitude || 0,
+        longitude: board.location?.longitude || 0,
+        locationName: board.location?.location_name || 'Unknown location',
+      },
+      date: board.date,
+      status: new Date(board.date) > new Date() ? 'OPEN' : 'CLOSED',
+      createdAt: board.createdAt,
+      updatedAt: board.updatedAt,
+      deletedAt: board.deletedAt,
+    };
   }
 }

--- a/src/board/repository/board.repository.ts
+++ b/src/board/repository/board.repository.ts
@@ -15,6 +15,7 @@ export class CustomBoardRepository {
   async paginateCreatedBoards(userId: number, pagingParams?: PagingParams) {
     const queryBuilder = this.boardRepository
       .createQueryBuilder('board')
+      .leftJoinAndSelect('board.location', 'location')
       .where('board.user_id = :userId', { userId })
       .orderBy('board.updatedAt', 'DESC');
 
@@ -48,6 +49,7 @@ export class CustomBoardRepository {
   ) {
     const queryBuilder = this.boardRepository
       .createQueryBuilder('board')
+      .leftJoinAndSelect('board.location', 'location')
       .where('board.chat_room IN (:...chatroomIds)', { chatroomIds })
       .andWhere('board.user_id != :userId', { userId })
       .orderBy('board.updatedAt', 'DESC');

--- a/src/chat-room/chat-room.service.ts
+++ b/src/chat-room/chat-room.service.ts
@@ -15,7 +15,7 @@ import { Board } from '../board/entities/board.entity';
 import { EventsGateway } from '../events/events.gateway';
 import { JwtService } from '@nestjs/jwt';
 import { SseResponseDto } from '../sse/dto/sse-response.dto';
-import { Observable, Subject } from 'rxjs';
+import { Observable } from 'rxjs';
 import { BoardService } from '../board/board.service';
 import { UserChatRoom } from 'src/user-chat-room/entities/user-chat-room.entity';
 import { SseService } from '../sse/sse.service';
@@ -245,27 +245,10 @@ export class ChatRoomService {
     return this.sseService.getRoomUpdatesObservable(chatRoom.id);
   }
 
-  // 특정 boardId에 대한 currentPerson 값을 반환하는 메서드
-  public async getCurrentCapacityForBoard(boardId: number): Promise<number> {
-    const chatRoom = await this.findChatRoomByBoardId(boardId);
-    if (chatRoom) {
-      return this.participants[chatRoom.id]?.size || 0;
-    }
-    return 0;
-  }
-
   public async findChatRoomByBoardId(boardId: number): Promise<ChatRoom> {
     return this.chatRoomRepository.findOne({
       where: { board: { id: boardId } },
       relations: ['userChatRooms', 'userChatRooms.user'],
     });
-  }
-
-  /* 채팅방 현재 인원 조회 */
-  async getMemberCount(chatRoomId: number): Promise<number> {
-    const chatRoom = await this.chatRoomRepository.findOne({
-      where: { id: chatRoomId },
-    });
-    return chatRoom ? chatRoom.member_count : 0;
   }
 }

--- a/src/sse/sse.module.ts
+++ b/src/sse/sse.module.ts
@@ -12,6 +12,7 @@ import { BoardsModule } from '../board/board.module';
 import { EventsModule } from '../events/evnets.module';
 import { MessageModule } from '../message/message.module';
 import { SseService } from './sse.service';
+import { BoardMapper } from '../board/dto/board.mapper';
 
 @Module({
   imports: [
@@ -25,6 +26,12 @@ import { SseService } from './sse.service';
   ],
   controllers: [SseController],
   exports: [SseService],
-  providers: [BoardService, LocationService, ChatRoomService, SseService],
+  providers: [
+    BoardService,
+    LocationService,
+    ChatRoomService,
+    SseService,
+    BoardMapper,
+  ],
 })
 export class SseModule {}

--- a/src/user-chat-room/repository/user-chat-room.repository.ts
+++ b/src/user-chat-room/repository/user-chat-room.repository.ts
@@ -23,6 +23,7 @@ export class CustomUserChatRoomRepository {
 
     return chatRooms.map((chatRoom) => chatRoom.chat_room_id);
   }
+
   async paginate(userId: number, pagingParams?: PagingParams) {
     const queryBuilder = this.userChatRoomRepository
       .createQueryBuilder('userchatroom')

--- a/src/user/dto/user.response.dto.ts
+++ b/src/user/dto/user.response.dto.ts
@@ -1,42 +1,32 @@
-import { IsString, IsNotEmpty, ValidateNested } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+import { IsNotEmpty, IsString } from 'class-validator';
 import { Type } from 'class-transformer';
 import { Cursor } from '../../global/common/dto/cursor.dto';
-import { Board } from '../../board/entities/board.entity';
+import { BoardResponseDto } from '../../board/dto/board-response.dto';
 
-class CreateBoards {
-  @ValidateNested({ each: true })
-  @Type(() => Board)
-  data: Board[];
+export class PaginatedBoardsDto {
+  @ApiProperty({ type: [BoardResponseDto] })
+  data: BoardResponseDto[];
 
-  @ValidateNested()
-  @Type(() => Cursor)
-  cursor: Cursor;
-}
-
-class JoinedBoards {
-  @ValidateNested({ each: true })
-  @Type(() => Board)
-  data: Board[];
-
-  @ValidateNested()
+  @ApiProperty()
   @Type(() => Cursor)
   cursor: Cursor;
 }
 
 export class UserResponseDto {
+  @ApiProperty()
   @IsString()
   @IsNotEmpty()
   username: string;
 
+  @ApiProperty()
   @IsString()
   @IsNotEmpty()
   region: string;
 
-  @ValidateNested()
-  @Type(() => CreateBoards)
-  createdBoards: CreateBoards;
+  @ApiProperty({ type: PaginatedBoardsDto })
+  createdBoards: PaginatedBoardsDto;
 
-  @ValidateNested()
-  @Type(() => JoinedBoards)
-  joinedBoards: JoinedBoards;
+  @ApiProperty({ type: PaginatedBoardsDto })
+  joinedBoards: PaginatedBoardsDto;
 }

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -13,7 +13,12 @@ import { UserDto } from './dto/user.dto';
 import { AuthGuard } from 'src/auth/auth.guard';
 import { Token } from 'src/auth/auth.decorator';
 import { UserResponseDto } from './dto/user.response.dto';
-import { ApiBearerAuth, ApiQuery, ApiTags } from '@nestjs/swagger';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiQuery,
+  ApiTags,
+} from '@nestjs/swagger';
 import { PagingParams } from '../global/common/type';
 import { UserChatRoomResponseDto } from './dto/user-chat-room.response.dto';
 
@@ -22,30 +27,31 @@ import { UserChatRoomResponseDto } from './dto/user-chat-room.response.dto';
 export class UserController {
   constructor(private readonly userService: UserService) {}
 
+  @ApiOperation({ summary: '유저가 생성한 게시글, 유저가 참여한 게시글 조회' })
   @ApiBearerAuth()
   @ApiQuery({
     name: 'createdBeforeCursor',
     required: false,
     type: String,
-    description: '생성한 게시물 목록의 이전 커서 값',
+    description: '생성한 게시글 목록의 이전 커서 값',
   })
   @ApiQuery({
     name: 'createdAfterCursor',
     required: false,
     type: String,
-    description: '생성한 게시물 목록의 다음 커서 값',
+    description: '생성한 게시글 목록의 다음 커서 값',
   })
   @ApiQuery({
     name: 'joinedBeforeCursor',
     required: false,
     type: String,
-    description: '참여한 게시물 목록의 이전 커서 값',
+    description: '참여한 게시글 목록의 이전 커서 값',
   })
   @ApiQuery({
     name: 'joinedAfterCursor',
     required: false,
     type: String,
-    description: '참여한 게시물 목록의 다음 커서 값',
+    description: '참여한 게시글 목록의 다음 커서 값',
   })
   @Get()
   @UseGuards(AuthGuard)
@@ -85,6 +91,7 @@ export class UserController {
   }
 
   /** 유저가 참여한 채팅방 반환 */
+  @ApiOperation({ summary: '유저가 참여한 채팅방' })
   @ApiQuery({
     name: 'beforeCursor',
     required: false,

--- a/src/user/user.module.ts
+++ b/src/user/user.module.ts
@@ -8,14 +8,23 @@ import { Board } from 'src/board/entities/board.entity';
 import { CustomUserChatRoomRepository } from '../user-chat-room/repository/user-chat-room.repository';
 import { CustomBoardRepository } from '../board/repository/board.repository';
 import { ChatRoomModule } from '../chat-room/chat-room.module';
+import { BoardMapper } from '../board/dto/board.mapper';
+import { LocationService } from '../location/location.service';
+import { Location } from '../location/entities/location.entity';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([User, UserChatRoom, Board]),
+    TypeOrmModule.forFeature([User, UserChatRoom, Board, Location]),
     ChatRoomModule,
   ],
   controllers: [UserController],
-  providers: [UserService, CustomUserChatRoomRepository, CustomBoardRepository],
+  providers: [
+    UserService,
+    CustomUserChatRoomRepository,
+    CustomBoardRepository,
+    BoardMapper,
+    LocationService,
+  ],
   exports: [UserService],
 })
 export class UserModule {}

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -134,19 +134,15 @@ export class UserService {
           return null; // null인 데이터를 건너뛰기
         }
 
-        const currentPerson: number = await this.chatRoomService.getMemberCount(
-          chatRoom.id,
-        );
-
         return {
           id: chatRoom.id,
           board: {
             boardId: board.id,
             title: board.title,
-            currentPerson,
-            max_capacity: board.max_capacity,
+            currentPerson: chatRoom.member_count,
+            maxCapacity: board.max_capacity,
             description: board.description,
-            start_time: board.start_time,
+            startTime: board.start_time,
             category: board.category,
             location: {
               id: board.location?.id || 0,


### PR DESCRIPTION
## Summary
게시글 리팩토링

## Description
- 게시글 단일 조회, 전체 조회, 게시글 수정 API에서 사용하던 인메모리 방식 객체 boardUpdates, currentCapacity 를 삭제하고 DB에서 채팅방 인원을 조회하도록 수정했습니다.
- board.service.ts에서 사용하지 않는 handleBoardUpdate 메서드(기존에는 char-room.service.ts에서 사용)를 삭제했습니다.
- 게시글 수정 API를 부분 업데이트 방식으로 업데이트 하도록 수정했습니다.
- entity를 dto로 매핑하는 코드를 board.mapper.ts 파일에 옮겨서 분리했습니다.
- 현재 참여중인 인원 필드명을 currentCapacity에서 currentPerson로 변경했습니다.
- 유저가 생성한 게시글과 유저가 참여한 게시글 조회와 자신이 참여한 채팅방 조회 시 반환되는 필드명 일부를 변경했습니다: max_capacity -> maxCapacity,  start_time -> startTime


## Screenshots
- 게시글 조회
![image](https://github.com/user-attachments/assets/29f681d2-2a43-4f91-8158-9b3977e6d6d7)

- 게시글 단일 조회
![image](https://github.com/user-attachments/assets/048f7628-69a5-4d19-a0ed-01cdb86d8c98)

- 게시글 수정
![image](https://github.com/user-attachments/assets/c58c3380-4a94-411a-b0f4-72ba7412c91c)
![image](https://github.com/user-attachments/assets/39914efe-3519-4b75-89d9-94780d43b31b)

- 유저가 참여한 채팅방
![image](https://github.com/user-attachments/assets/3c5f66fd-ec89-4096-8c69-c7281cfb5989)


## Test Checklist
- [x] 게시글 조회 API
- [x] 게시글 단일 조회 API
- [x] 게시글 수정 API
- [x] 유저가 참여한 채팅방 조회 API
