### PR TITLE
bug : websocket 필요 없는 부분 삭제

### DIFF
--- a/src/chat-room/chat-room.service.ts
+++ b/src/chat-room/chat-room.service.ts
@@ -216,7 +216,7 @@ export class ChatRoomService {
     // 실시간 메시지 전송
     this.eventsGateway.broadcastMessage('broadcastMessage', {
       chatRoomId: chatRoomId,
-      message: message.content,
+      content: message.content,
       nickName: username,
     });
 

--- a/src/events/events.gateway.ts
+++ b/src/events/events.gateway.ts
@@ -52,5 +52,7 @@ export class EventsGateway implements OnGatewayConnection, OnGatewayDisconnect {
       message.content,
       message.nickname,
     );
+
+    this.broadcastMessage('newMessage', message);
   }
 }

--- a/src/events/events.gateway.ts
+++ b/src/events/events.gateway.ts
@@ -25,25 +25,9 @@ export class EventsGateway implements OnGatewayConnection, OnGatewayDisconnect {
 
   handleConnection(client: Socket): void {
     this.logger.log('Client connected: ' + client.id);
-    client.leave(client.id);
-    client.data.chatRoomId = 'room:lobby';
-    client.join('room:lobby');
   }
 
   handleDisconnect(client: Socket): void {
-    const { chatRoomId } = client.data;
-    if (
-      chatRoomId !== 'room:lobby' &&
-      !this.server.sockets.adapter.rooms.get(chatRoomId)
-    ) {
-      // client.id 대신 사용자의 실제 ID를 전달합니다.
-      const userId = parseInt(client.data.userId, 10); // client.data.userId가 있다고 가정
-      this.chatRoomService.leaveChatRoomByBoardId(
-        parseInt(chatRoomId.split(':')[1]),
-        userId,
-      );
-      this.server.emit('getChatRoomList', this.chatRoomService.getChatRooms());
-    }
     this.logger.log('Client disconnected: ' + client.id);
   }
   broadcastMessage(event: string, message: any) {


### PR DESCRIPTION
## Summary
- websocket에서 나중에 방 입장 / 퇴장 websocket으로 할 수 있으니까 일단 넣어놓자 했는데 필요없는 코드가 되어서 삭제

- websocket 아무 무리 없이 잘 돌아가는 거 확인함
- @baekjiyun  말한 message -> contnet 변경

## Description
<!-- *어떤 코드가 추가/변경 됐는지* -->
```
 handleConnection(client: Socket): void {
    this.logger.log('Client connected: ' + client.id);
    client.leave(client.id);
    client.data.chatRoomId = 'room:lobby';
    client.join('room:lobby');
  }

  handleDisconnect(client: Socket): void {
    const { chatRoomId } = client.data;
    if (
      chatRoomId !== 'room:lobby' &&
      !this.server.sockets.adapter.rooms.get(chatRoomId)
    ) {
      // client.id 대신 사용자의 실제 ID를 전달합니다.
      const userId = parseInt(client.data.userId, 10); // client.data.userId가 있다고 가정
      this.chatRoomService.leaveChatRoomByBoardId(
        parseInt(chatRoomId.split(':')[1]),
        userId,
      );
      this.server.emit('getChatRoomList', this.chatRoomService.getChatRooms());
    }
    this.logger.log('Client disconnected: ' + client.id);
  }
```
- 여기서 방 입장 / 퇴장 부분 삭제

## Screenshots
<!-- *실행 결과 스크린샷* -->
<img width="517" alt="image" src="https://github.com/user-attachments/assets/fc6c1a4b-bf30-4fcd-9f23-58d95edd71cc">


## Test Checklist
<!--  *테스트할 사람이 어떤 것을 확인하면 좋을지* -->
- [ ] @non-cpu 
- [ ] @suhyeon0921 
- [ ] @baekjiyun 
