### PR TITLE
[bug] 최대인원 수정 버그 해결 및 entity 수정

### DIFF
--- a/src/board/board.module.ts
+++ b/src/board/board.module.ts
@@ -5,13 +5,14 @@ import { BoardController } from './board.controller';
 import { Board } from './entities/board.entity';
 import { UserModule } from '../user/user.module';
 import { LocationModule } from '../location/location.module';
-import { ChatRoomModule } from '../chat-room/chat-room.module';
 import { Message } from '../message/entities/message.entity';
 import { BoardMapper } from './dto/board.mapper';
+import { ChatRoom } from '../chat-room/entities/chat-room.entity';
+import { ChatRoomModule } from '../chat-room/chat-room.module';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Board, Message]),
+    TypeOrmModule.forFeature([Board, Message, ChatRoom]),
     UserModule,
     LocationModule,
     forwardRef(() => ChatRoomModule),

--- a/src/board/board.service.ts
+++ b/src/board/board.service.ts
@@ -251,7 +251,7 @@ export class BoardService {
         location_name,
       });
     } else {
-      newLocation.location_name = location_name;
+      newLocation.locationName = location_name;
       await this.locationService.updateLocation(newLocation);
     }
 

--- a/src/board/board.service.ts
+++ b/src/board/board.service.ts
@@ -21,6 +21,7 @@ import { Message } from '../message/entities/message.entity';
 import { User } from '../user/entities/user.entity';
 import { ChatRoom } from '../chat-room/entities/chat-room.entity';
 import { BoardMapper } from './dto/board.mapper';
+import { ChatRoomMapper } from '../chat-room/dto/chat-room.mapper';
 
 @Injectable()
 export class BoardService {
@@ -31,10 +32,13 @@ export class BoardService {
     private readonly boardRepository: Repository<Board>,
     @InjectRepository(Message)
     private readonly messageRepository: Repository<Message>,
+    @InjectRepository(ChatRoom)
+    private readonly chatRoomRepository: Repository<ChatRoom>,
     private readonly locationService: LocationService,
     private readonly chatRoomService: ChatRoomService,
     private dataSource: DataSource,
     private readonly boardMapper: BoardMapper,
+    private readonly chatRoomMapper: ChatRoomMapper,
   ) {}
 
   async createBoard(
@@ -65,8 +69,6 @@ export class BoardService {
         user,
         ...createBoardDto,
         location: newLocation as DeepPartial<Location>,
-        max_capacity: createBoardDto.maxCapacity,
-        start_time: createBoardDto.startTime,
       });
 
       const savedBoard: Board = await queryRunner.manager.save(board);
@@ -76,11 +78,12 @@ export class BoardService {
         await this.chatRoomService.createChatRoomForBoard(
           queryRunner,
           savedBoard,
+          createBoardDto.maxCapacity,
           user,
         );
 
       // Board에 ChatRoom을 연결
-      savedBoard.chat_room = chatRoom;
+      savedBoard.chatRoom = chatRoom;
       await queryRunner.manager.save(savedBoard);
 
       await queryRunner.commitTransaction();
@@ -89,11 +92,7 @@ export class BoardService {
         `게시판과 채팅방이 생성되었습니다. Board ID: ${savedBoard.id}, ChatRoom ID: ${chatRoom.id}`,
       );
 
-      return this.boardMapper.toBoardResponseDto(
-        savedBoard,
-        user.id,
-        chatRoom.member_count,
-      );
+      return this.boardMapper.toBoardResponseDto(savedBoard, user.id, chatRoom);
     } catch (err) {
       await queryRunner.rollbackTransaction();
       if (err.code === '23505') {
@@ -136,11 +135,7 @@ export class BoardService {
           );
         }
 
-        return this.boardMapper.toBoardResponseDto(
-          board,
-          undefined,
-          chatRoom.member_count,
-        );
+        return this.boardMapper.toBoardResponseDto(board, undefined, chatRoom);
       }),
     );
 
@@ -168,11 +163,7 @@ export class BoardService {
       throw new NotFoundException('게시판에 연결된 채팅방을 찾을 수 없습니다.');
     }
 
-    return this.boardMapper.toBoardResponseDto(
-      board,
-      userId,
-      chatRoom.member_count,
-    );
+    return this.boardMapper.toBoardResponseDto(board, userId, chatRoom);
   }
 
   async updateBoard(
@@ -195,22 +186,29 @@ export class BoardService {
       );
     }
 
-    const updatedBoard: Board = await this.boardMapper.updateBoardFromDto(
-      board,
-      updateBoardDto,
-    );
-    const savedBoard: Board = await this.boardRepository.save(updatedBoard);
-
     const chatRoom: ChatRoom =
       await this.chatRoomService.findChatRoomByBoardId(id);
     if (!chatRoom) {
       throw new NotFoundException('게시판에 연결된 채팅방을 찾을 수 없습니다.');
     }
 
+    const updatedBoard: Board = await this.boardMapper.updateBoardFromDto(
+      board,
+      updateBoardDto,
+    );
+    const savedBoard: Board = await this.boardRepository.save(updatedBoard);
+
+    const updatedChatRoom: ChatRoom = this.chatRoomMapper.updateChatRoomFromDto(
+      chatRoom,
+      updateBoardDto,
+    );
+    const savedChatRoom: ChatRoom =
+      await this.chatRoomRepository.save(updatedChatRoom);
+
     return this.boardMapper.toBoardResponseDto(
       savedBoard,
       userId,
-      chatRoom.member_count || 0,
+      savedChatRoom,
     );
   }
 
@@ -229,8 +227,8 @@ export class BoardService {
     }
 
     // 먼저 관련된 메시지를 삭제합니다.
-    if (board.chat_room?.messages) {
-      await this.messageRepository.remove(board.chat_room.messages);
+    if (board.chatRoom?.messages) {
+      await this.messageRepository.remove(board.chatRoom.messages);
     }
 
     await this.boardRepository.remove(board);

--- a/src/board/dto/board.mapper.ts
+++ b/src/board/dto/board.mapper.ts
@@ -12,14 +12,13 @@ export class BoardMapper {
   toBoardResponseDto(
     board: Board,
     userId: number | undefined,
-    currentPerson: number,
+    chatRoom: ChatRoom,
   ): BoardResponseDto {
     const {
       id,
       title,
-      max_capacity,
       description,
-      start_time,
+      startTime,
       date,
       category,
       createdAt,
@@ -33,10 +32,10 @@ export class BoardMapper {
     return {
       id,
       title,
-      maxCapacity: max_capacity,
-      currentPerson,
+      maxCapacity: chatRoom.maxMemberCount,
+      currentPerson: chatRoom.memberCount,
       description,
-      startTime: start_time,
+      startTime: startTime,
       date,
       category,
       location: {
@@ -72,11 +71,9 @@ export class BoardMapper {
       board.category = updateBoardDto.category;
     if (updateBoardDto.description !== undefined)
       board.description = updateBoardDto.description;
-    if (updateBoardDto.maxCapacity !== undefined)
-      board.max_capacity = updateBoardDto.maxCapacity;
     if (updateBoardDto.date !== undefined) board.date = updateBoardDto.date;
     if (updateBoardDto.startTime !== undefined)
-      board.start_time = updateBoardDto.startTime;
+      board.startTime = updateBoardDto.startTime;
 
     return board;
   }
@@ -95,10 +92,10 @@ export class BoardMapper {
     return {
       id: board.id,
       title: board.title,
-      currentPerson: chatRoom.member_count,
-      maxCapacity: board.max_capacity,
+      currentPerson: chatRoom.memberCount,
+      maxCapacity: chatRoom.maxMemberCount,
       description: board.description,
-      startTime: board.start_time,
+      startTime: board.startTime,
       category: board.category,
       location: {
         id: board.location?.id || 0,

--- a/src/board/dto/board.mapper.ts
+++ b/src/board/dto/board.mapper.ts
@@ -42,7 +42,7 @@ export class BoardMapper {
         id: location.id,
         latitude: location.latitude,
         longitude: location.longitude,
-        locationName: location.location_name,
+        locationName: location.locationName,
       },
       createdAt,
       updatedAt,
@@ -61,8 +61,8 @@ export class BoardMapper {
       board.location = await this.locationService.updateLocation({
         ...board.location,
         ...updateBoardDto.location,
-        location_name:
-          updateBoardDto.locationName || board.location.location_name,
+        locationName:
+          updateBoardDto.locationName || board.location.locationName,
       });
     }
 
@@ -101,7 +101,7 @@ export class BoardMapper {
         id: board.location?.id || 0,
         latitude: board.location?.latitude || 0,
         longitude: board.location?.longitude || 0,
-        locationName: board.location?.location_name || 'Unknown location',
+        locationName: board.location?.locationName || 'Unknown location',
       },
       date: board.date,
       status: new Date(board.date) > new Date() ? 'OPEN' : 'CLOSED',

--- a/src/board/entities/board.entity.ts
+++ b/src/board/entities/board.entity.ts
@@ -28,17 +28,13 @@ export class Board extends TimeStamp {
   @ApiProperty({ description: '제목', nullable: true })
   title: string;
 
-  @Column({ type: 'int' })
-  @ApiProperty({ description: '최대 참가 인원' })
-  max_capacity: number;
-
   @Column({ type: 'varchar', nullable: true })
   @ApiProperty({ description: '설명', nullable: true })
   description: string;
 
   @Column({ type: 'time', nullable: true })
   @ApiProperty({ description: '시작시간', nullable: true })
-  start_time: string;
+  startTime: string;
 
   @ManyToOne(() => Location, (location) => location.boards)
   @JoinColumn({ name: 'location_id' })
@@ -55,5 +51,5 @@ export class Board extends TimeStamp {
 
   @OneToOne(() => ChatRoom, (chatRoom) => chatRoom.board)
   @JoinColumn({ name: 'chat_room_id' })
-  chat_room: ChatRoom;
+  chatRoom: ChatRoom;
 }

--- a/src/chat-room/chat-room.module.ts
+++ b/src/chat-room/chat-room.module.ts
@@ -11,6 +11,7 @@ import { Board } from '../board/entities/board.entity';
 import { UserModule } from '../user/user.module';
 import { BoardsModule } from '../board/board.module';
 import { SseModule } from '../sse/sse.module';
+import { ChatRoomMapper } from './dto/chat-room.mapper';
 
 @Module({
   imports: [
@@ -22,7 +23,7 @@ import { SseModule } from '../sse/sse.module';
     forwardRef(() => SseModule),
   ],
   controllers: [ChatRoomController],
-  providers: [ChatRoomService],
-  exports: [ChatRoomService, TypeOrmModule],
+  providers: [ChatRoomService, ChatRoomMapper],
+  exports: [ChatRoomService, TypeOrmModule, ChatRoomMapper],
 })
 export class ChatRoomModule {}

--- a/src/chat-room/chat-room.service.spec.ts
+++ b/src/chat-room/chat-room.service.spec.ts
@@ -183,7 +183,7 @@ describe('ChatRoomService', () => {
 
       await service.leaveChatRoomByBoardId(1, 1);
       expect(chatRoomRepository.save).toHaveBeenCalledWith(
-        expect.objectContaining({ member_count: 1 }),
+        expect.objectContaining({ memberCount: 1 }),
       );
     });
 

--- a/src/chat-room/chat-room.service.spec.ts
+++ b/src/chat-room/chat-room.service.spec.ts
@@ -10,10 +10,10 @@ import { BoardService } from '../board/board.service';
 import { EventsGateway } from '../events/events.gateway';
 import { SseService } from '../sse/sse.service';
 import {
-  NotFoundException,
-  UnauthorizedException,
   BadRequestException,
   ConflictException,
+  NotFoundException,
+  UnauthorizedException,
 } from '@nestjs/common';
 
 describe('ChatRoomService', () => {
@@ -127,8 +127,8 @@ describe('ChatRoomService', () => {
     it('채팅방에 참가할 때 멤버 수가 증가해야 합니다', async () => {
       const chatRoom = {
         id: 1,
-        member_count: 1,
-        max_member_count: 5,
+        memberCount: 1,
+        maxMemberCount: 5,
         userChatRooms: [],
       } as ChatRoom;
       jest.spyOn(service, 'findChatRoomByBoardId').mockResolvedValue(chatRoom);
@@ -143,8 +143,8 @@ describe('ChatRoomService', () => {
     it('채팅방 최대 인원을 초과할 수 없습니다', async () => {
       const chatRoom = {
         id: 1,
-        member_count: 5,
-        max_member_count: 5,
+        memberCount: 5,
+        maxMemberCount: 5,
         userChatRooms: [],
       } as ChatRoom;
       jest.spyOn(service, 'findChatRoomByBoardId').mockResolvedValue(chatRoom);
@@ -157,8 +157,8 @@ describe('ChatRoomService', () => {
     it('이미 채팅방에 들어가 있는 경우 ConflictException을 던져야 합니다', async () => {
       const chatRoom = {
         id: 1,
-        member_count: 1,
-        max_member_count: 5,
+        memberCount: 1,
+        maxMemberCount: 5,
         userChatRooms: [{ user: { id: 1 } }],
       } as ChatRoom;
       jest.spyOn(service, 'findChatRoomByBoardId').mockResolvedValue(chatRoom);
@@ -173,7 +173,7 @@ describe('ChatRoomService', () => {
     it('채팅방에서 나갈 때 멤버 수가 감소해야 합니다', async () => {
       const chatRoom = {
         id: 1,
-        member_count: 2,
+        memberCount: 2,
         userChatRooms: [{ user: { id: 1 } }],
       } as ChatRoom;
       jest.spyOn(chatRoomRepository, 'findOne').mockResolvedValue(chatRoom);

--- a/src/chat-room/chat-room.service.spec.ts
+++ b/src/chat-room/chat-room.service.spec.ts
@@ -135,7 +135,7 @@ describe('ChatRoomService', () => {
 
       await service.joinChatRoomByBoardId(1, 1);
       expect(chatRoomRepository.save).toHaveBeenCalledWith(
-        expect.objectContaining({ member_count: 2 }),
+        expect.objectContaining({ memberCount: 2 }),
       );
       expect(userChatRoomRepository.save).toHaveBeenCalled();
     });
@@ -226,7 +226,7 @@ describe('ChatRoomService', () => {
         'broadcastMessage',
         {
           chatRoomId: 1,
-          message: 'Hello',
+          content: 'Hello',
           nickName: 'User',
         },
       );

--- a/src/chat-room/dto/chat-room.mapper.ts
+++ b/src/chat-room/dto/chat-room.mapper.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@nestjs/common';
+import { ChatRoom } from '../entities/chat-room.entity';
+import { UpdateBoardDto } from '../../board/dto/update-board';
+
+@Injectable()
+export class ChatRoomMapper {
+  updateChatRoomFromDto(
+    chatRoom: ChatRoom,
+    updateBoardDto: Partial<UpdateBoardDto>,
+  ): ChatRoom {
+    if (updateBoardDto.maxCapacity !== undefined) {
+      chatRoom.maxMemberCount = updateBoardDto.maxCapacity;
+    }
+    return chatRoom;
+  }
+}

--- a/src/chat-room/entities/chat-room.entity.ts
+++ b/src/chat-room/entities/chat-room.entity.ts
@@ -20,17 +20,17 @@ export class ChatRoom extends TimeStamp {
 
   @Column({ name: 'chat_name', type: 'varchar', length: 100, nullable: false })
   @ApiProperty({ description: '채팅방 이름' })
-  chat_name: string;
+  chatName: string;
 
   @Column({ name: 'member_count', type: 'int', nullable: false })
   @ApiProperty({ description: '현재 채팅방 인원' })
-  member_count: number;
+  memberCount: number;
 
   @Column({ name: 'max_member_count', type: 'int', nullable: false })
   @ApiProperty({ description: '채팅방 최대 인원' })
-  max_member_count: number;
+  maxMemberCount: number;
 
-  @OneToOne(() => Board, (board) => board.chat_room, { onDelete: 'CASCADE' })
+  @OneToOne(() => Board, (board) => board.chatRoom, { onDelete: 'CASCADE' })
   @JoinColumn()
   board: Board;
 

--- a/src/location/entities/location.entity.ts
+++ b/src/location/entities/location.entity.ts
@@ -1,4 +1,4 @@
-import { Entity, PrimaryGeneratedColumn, Column, OneToMany } from 'typeorm';
+import { Column, Entity, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
 import { ApiProperty } from '@nestjs/swagger';
 import { Board } from '../../board/entities/board.entity';
 
@@ -18,7 +18,7 @@ export class Location {
 
   @Column({ type: 'varchar', length: 100, nullable: false })
   @ApiProperty({ description: '위치 이름', nullable: false })
-  location_name: string;
+  locationName: string;
 
   @Column({ type: 'int', nullable: true })
   @ApiProperty({ description: '위치 순서', nullable: true })

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -162,10 +162,10 @@ export class UserService {
           board: {
             boardId: board.id,
             title: board.title,
-            currentPerson: chatRoom.member_count,
-            maxCapacity: board.max_capacity,
+            currentPerson: chatRoom.memberCount,
+            maxCapacity: chatRoom.maxMemberCount,
             description: board.description,
-            startTime: board.start_time,
+            startTime: board.startTime,
             category: board.category,
             location: {
               id: board.location?.id || 0,

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -171,7 +171,7 @@ export class UserService {
               id: board.location?.id || 0,
               latitude: board.location?.latitude || 0,
               longitude: board.location?.longitude || 0,
-              locationName: board.location?.location_name || 'Unknown location',
+              locationName: board.location?.locationName || 'Unknown location',
             },
             date: board.date,
             status: new Date(board.date) > new Date() ? 'OPEN' : 'CLOSED',


### PR DESCRIPTION
## Description
- 최대인원이 board.max_capacity와 chatRoom.max_member_count로 관리되서 chatRoom.maxMemberCount로 관리하도록 수정했습니다.
- 게시글의 최대인원수를 변경했을 시 수정이 되지 않던 버그를 해결했습니다.
- entity의 컨벤션을 카멜케이스로 통일했습니다.


## Screenshots
<!-- *실행 결과 스크린샷* -->
![image](https://github.com/user-attachments/assets/2620fa78-4350-40bd-888a-e15eff1d1a04)
![image](https://github.com/user-attachments/assets/527c757b-168a-4917-84a4-17d62354941d)
![image](https://github.com/user-attachments/assets/c93c6b8c-fa67-4f4c-ba9c-eef4d81123c7)


## Test Checklist
<!--  *테스트할 사람이 어떤 것을 확인하면 좋을지* -->
- [x] 게시글 생성 후 최대인원을 수정했을 시 정상적으로 수정되는지 
